### PR TITLE
Remove Format-String for CommandLine string transfer.

### DIFF
--- a/studio-nip.ps1
+++ b/studio-nip.ps1
@@ -513,7 +513,7 @@ switch ($PsCmdlet.ParameterSetName)
                     $ProjectDescription = $json.ProjectSettings.ProjectDescription | Format-String
                     $CompressionMethod = $json.OutputSettings.CompressionMethod | Format-String
                     $EncryptionMethod = $json.OutputSettings.EncryptionMethod | Format-String
-                    $CommandLine = $json.ProjectSettings.CommandLine | Format-String
+                    $CommandLine = $json.ProjectSettings.CommandLine
                     $CommandLineParams = $json.ProjectSettings.CommandLineParams
                     $IconFile = $json.ProjectSettings.IconFile | Format-String
                     if(-NOT ([string]::IsNullOrEmpty($IconFile)))


### PR DESCRIPTION
Remove the Format-String for CommandLine string transfer. When both the command and its argument have the space in the string, the double quotes need to be kept.